### PR TITLE
Fix hex transparency

### DIFF
--- a/src/runtime/style/color.test.ts
+++ b/src/runtime/style/color.test.ts
@@ -1,0 +1,29 @@
+import { describe } from 'zip-tap';
+import { Color } from './color';
+
+describe(`Color`, it => {
+	it(`should create a color`, expect => {
+		const color = new Color([255, 0, 0]);
+
+		expect(color.hex).toBe(`#ff0000`);
+	});
+
+	it(`should always return lowercase, six or eight hex`, expect => {
+		expect(new Color({ hex: `F0a` }).hex).toBe(`#ff00aa`);
+	});
+
+	it(`should recreate itself when prompted to do so`, expect => {
+		const color = new Color([45, 34, 67]);
+
+		expect(color.hex).toBe(`#2d2243`);
+
+		color.recreate([12, 89, 180]);
+
+		expect(color.hex).toBe(`#0c59b4`);
+	});
+
+	it(`should handle transparency values`, expect => {
+		expect(new Color({ hex: `14fDe32a` }).hex).toBe(`#14fde32a`);
+		expect(new Color({ rgb: [45, 134, 181, 0.7] }).hex).toBe(`#2d86b5b3`);
+	});
+});

--- a/src/runtime/style/color.ts
+++ b/src/runtime/style/color.ts
@@ -19,7 +19,7 @@ export class Color {
 		} else if (options.rgb) {
 			this.hex = this.rgbToHex(...options.rgb);
 		} else if (options.hex) {
-			this.hex = this.ensureSixOrEightHex(this.ensureHash(options.hex));
+			this.hex = this.ensureAllLowercase(this.ensureSixOrEightHex(this.ensureHash(options.hex)));
 		}
 
 		if (!Array.isArray(options) && options.alpha) {
@@ -52,6 +52,10 @@ export class Color {
 		arr.splice(5, 0, arr[5]);
 
 		return arr.join('');
+	}
+
+	private ensureAllLowercase(hex: string) {
+		return hex.toLowerCase();
 	}
 
 	private ensureHash(hex: string): string {

--- a/src/runtime/style/color.ts
+++ b/src/runtime/style/color.ts
@@ -38,7 +38,7 @@ export class Color {
 
 		if (a === 0) return baseHex + `00`;
 		if (!a || a === 1) return baseHex;
-		return baseHex + this.componentToHex(a * 255);
+		return baseHex + this.componentToHex(Math.round(a * 255));
 	}
 
 	private ensureSixOrEightHex(hex: string): string {


### PR DESCRIPTION
Fixes #23 

Just needed a `Math.round` on the `alpha * 255` expression.